### PR TITLE
Don't allow killing bird again while it's in its dying animation

### DIFF
--- a/src/commonMain/kotlin/main.kt
+++ b/src/commonMain/kotlin/main.kt
@@ -137,6 +137,7 @@ class Bird(birdSpriteSheet: Bitmap, val eatApple: Sound, val birdCry: Sound) :
 	}
 
 	private suspend fun hit() {
+		if (hit) return
 		bus.send(HitBirdEvent())
 		birdCry.play()
 		hit = true


### PR DESCRIPTION
There was a bug allowing players to kill the bird while it was in its dying animation which resulted in glitches.
This PR disallows running the hit method again while the bird is already hit